### PR TITLE
Updated to support being a child object, custom height/width, placeholder on constructor

### DIFF
--- a/dev/TextInput.js
+++ b/dev/TextInput.js
@@ -1,13 +1,14 @@
 /**
  * Created by Andrew on 3/19/16.
+ * Updated by Nick Garza on 10/17/2018
  */
 class TextInput extends createjs.Container {
   constructor() {
     super();
 
     // Field Settings
-    this.width = 200;
-    this.height = 40;
+    this.width = 60;
+    this.height = 30;
 
     // Text Settings
     this.placeHolder = '';
@@ -46,6 +47,8 @@ class TextInput extends createjs.Container {
   _setupDomNode() {
     this._hiddenInput = document.createElement('input');
     this._hiddenInput.type = 'text';
+    this._hiddenInput.size = '4';
+    this._hiddenInput.maxLength = '5';
     this._hiddenInput.style.display = 'none';
     this._hiddenInput.style.position = 'absolute';
     this._hiddenInput.style.zIndex = -100;
@@ -131,17 +134,19 @@ class TextInput extends createjs.Container {
   _setupListeners() {
     window.addEventListener('click', (e) => {
       // Page
-      const pX = e.pageX;
+      //coordinates of mouse click
+      const pX = e.pageX; 
       const pY = e.pageY;
       // Canvas
       if (this.stage === null) return;
-      const cX = this.stage.canvas.offsetLeft;
-      const cY = this.stage.canvas.offsetTop;
+      const cX = this.parent.stage.canvas.offsetLeft;
+      const cY = this.parent.stage.canvas.offsetTop;
       // Local
-      const lX = pX - cX - this.x;
-      const lY = pY - cY - this.y;
-
+      const lX = pX - cX - this.parent.x - this.x;
+      const lY = pY - cY - this.parent.y - this.y;
+      //console.log({x: lX, y: lY});
       this._click({x: lX, y: lY});
+      //this._click({x:0, y:0})
     });
     this._hiddenInput.addEventListener('input', (e) => {
       if (this._focused) {
@@ -184,8 +189,9 @@ class TextInput extends createjs.Container {
 
   _selectInput() {
     this._hiddenInput.style.display = 'block';
-    this._hiddenInput.style.left = (this.x + this.stage.canvas.offsetLeft + this._padding) + 'px';
-    this._hiddenInput.style.top = (this.y + this.stage.canvas.offsetTop + this._padding) + 'px';
+    //this._hiddenInput.style.visibility = 'hidden';
+    this._hiddenInput.style.left = (this.x + this.parent.stage.canvas.offsetLeft + this._padding + this.parent.x) + 'px';
+    this._hiddenInput.style.top = (this.y + this.parent.stage.canvas.offsetTop + this._padding + this.parent.y) + 'px';
     this._hiddenInput.focus();
   }
 

--- a/dev/TextInput.js
+++ b/dev/TextInput.js
@@ -1,17 +1,31 @@
 /**
  * Created by Andrew on 3/19/16.
- * Updated by Nick Garza on 10/17/2018
  */
 class TextInput extends createjs.Container {
-  constructor() {
+  constructor(boxSize, placeholder) {
     super();
 
+    console.log(boxSize);
+
     // Field Settings
-    this.width = 60;
-    this.height = 30;
+    if(boxSize)
+    {
+      this.width = boxSize.width;
+      this.height = boxSize.height;
+    } else {
+      this.width = 200;
+      this.height = 40;
+    }
+    
 
     // Text Settings
-    this.placeHolder = '';
+    if(placeholder)
+    {
+      this.placeHolder = placeholder;
+    } else {
+      this.placeHolder = '';
+    }
+    
     this.placeHolderTextColor = '#999';
     this.textColor = '#222';
     this.fontSize = 20;
@@ -47,8 +61,11 @@ class TextInput extends createjs.Container {
   _setupDomNode() {
     this._hiddenInput = document.createElement('input');
     this._hiddenInput.type = 'text';
-    this._hiddenInput.size = '4';
-    this._hiddenInput.maxLength = '5';
+    //setting up custom size
+    let size = Math.ceil(this.width / 15).toString(); 
+    let maxLength = Math.ceil(this.width / 12).toString(); 
+    this._hiddenInput.size = size;
+    this._hiddenInput.maxLength = maxLength;
     this._hiddenInput.style.display = 'none';
     this._hiddenInput.style.position = 'absolute';
     this._hiddenInput.style.zIndex = -100;
@@ -144,9 +161,7 @@ class TextInput extends createjs.Container {
       // Local
       const lX = pX - cX - this.parent.x - this.x;
       const lY = pY - cY - this.parent.y - this.y;
-      //console.log({x: lX, y: lY});
       this._click({x: lX, y: lY});
-      //this._click({x:0, y:0})
     });
     this._hiddenInput.addEventListener('input', (e) => {
       if (this._focused) {
@@ -189,7 +204,6 @@ class TextInput extends createjs.Container {
 
   _selectInput() {
     this._hiddenInput.style.display = 'block';
-    //this._hiddenInput.style.visibility = 'hidden';
     this._hiddenInput.style.left = (this.x + this.parent.stage.canvas.offsetLeft + this._padding + this.parent.x) + 'px';
     this._hiddenInput.style.top = (this.y + this.parent.stage.canvas.offsetTop + this._padding + this.parent.y) + 'px';
     this._hiddenInput.focus();

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,31 @@ Basic JavaScript usage:
       stage.update();
     });
 
+Custom Width/Height and placeholder usage:
+
+    // Grab our canvas and setup the stage
+    const canvas = document.getElementById('canvasId');
+    const stage = new createjs.Stage(canvas);
+    
+    // Create and place our text field on the canvas
+    const newDimensions = {
+        height: 30,
+        width: 60
+    }
+    const textField = new TextInput(newDimensions, "Placeholder Text");
+    textField.y = textField.x = 100;
+    stage.addChild(textField);
+    
+    // Updates the text field to the new internal data (ie. placeholder)
+    // I may allow an optional internal data watcher, but I feel if there are a large amount of 
+    // fields this could become performance slow
+    textField.update();
+    
+    // Standard auto refresh
+    createjs.Ticker.on('tick', function () {
+      stage.update();
+    });
+
 ## License
 
 [MIT License](https://opensource.org/licenses/MIT) 


### PR DESCRIPTION
This update supports being a child object (for example, if I generate a container object, I may want an input field as a child) as well as custom height/width to fit those cases on construction.

You can see it in action here: http://www.adagar.net/experiments/ratiotables/